### PR TITLE
Restore C64 sequence and enhance fractal effect

### DIFF
--- a/mandelbrot.frag
+++ b/mandelbrot.frag
@@ -1,104 +1,30 @@
 #version 120
 
-uniform vec2  uCenter, uCenterHi, uCenterLo;
+uniform vec2  uCenter;
 uniform float uZoom;
 uniform ivec2 uResolution;
 uniform int   uMaxIter;
-uniform float uBrightness;   // try 1.15
-uniform float uGamma;        // try 1.80
-uniform float uContrast;     // try 1.25
 
-// ---- Cosine palette ----
-vec3 cosPalette(float t, vec3 a, vec3 b, vec3 c, vec3 d){
-    return a + b * cos(6.2831853 * (c * t + d));
-}
-
-// Neutral monochrome palette (subtle cool bias, no pink)
-vec3 palNeutral(float t){
-    // identical 'c' keeps channels nearly equal -> greys
-    vec3 col = cosPalette(t,
-        vec3(0.34),          // base grey
-        vec3(0.62),          // amplitude
-        vec3(0.82),          // frequency
-        vec3(0.08,0.10,0.12) // very slight RGB phase offset (cool tint)
-    );
-    return clamp(col, 0.0, 1.0);
-}
-
-vec3 colorize(vec2 c){
-    vec2  z = vec2(0.0);
-    float r2 = 0.0;
-    float trap = 1e20;
-    int   it = 0;
-
-    for (int i=0;i<20000;++i){
-        if (i >= uMaxIter) break;
-        z = vec2(z.x*z.x - z.y*z.y, 2.0*z.x*z.y) + c;
-        r2 = dot(z,z);
-        trap = min(trap, abs(z.x)+abs(z.y));
-        if (r2 > 4.0){ it = i; break; }
-        if (i == uMaxIter-1) it = uMaxIter;
-    }
-
-    // In-set: dark graphite
-    if (it >= uMaxIter) return vec3(0.03, 0.035, 0.04);
-
-    // Smooth iterations
-    float mu = float(it) + 1.0 - log2(log2(sqrt(r2)));
-    float t  = mu / float(uMaxIter);
-
-    // More shades (no candy bands)
-    float bands = 3.2;                 // 2.5–5.0
-    float tt = fract(t * bands);
-
-    vec3 col = palNeutral(tt);
-
-    // Orbit-trap highlight (very gentle)
-    float trapW = smoothstep(0.0, 0.35, 1.0 - clamp(trap, 0.0, 2.0));
-    col = mix(col, vec3(0.95), trapW * 0.25);
-
-    // Edge bloom a touch
-    float edge = clamp(1.0 - tt*tt*2.0, 0.0, 1.0);
-    col = mix(col, vec3(1.0), edge * 0.06);
-
-    // Heavy desaturation → mostly greys (but not flat)
-    float luma = dot(col, vec3(0.299, 0.587, 0.114));
-    col = mix(col, vec3(luma), 0.85); // 0.85 = 85% towards grey
-
-    // Tone ops
-    col = clamp(col, 0.0, 1.0);
-    col = (col - 0.5) * max(uContrast, 0.0) + 0.5;
-    col *= uBrightness;
-    col = pow(clamp(col, 0.0, 1.0), vec3(1.0 / max(uGamma, 0.0001)));
-    return clamp(col, 0.0, 1.0);
+vec3 palette(float t){
+    return 0.5 + 0.5*cos(6.2831853*(vec3(0.0,0.33,0.67)+t));
 }
 
 void main(){
-    vec2 res    = vec2(uResolution);
-    vec2 px     = 1.0 / res;
-    vec2 split  = uCenterHi + uCenterLo;
-    vec2 center = (dot(split, split) > 0.0) ? split : uCenter;
+    vec2 res = vec2(uResolution);
+    vec2 uv  = (gl_FragCoord.xy / res) * 2.0 - 1.0;
+    uv.x *= res.x / res.y;
 
-    vec2 uv = gl_FragCoord.xy * px * 2.0 - 1.0;
-    float aspect = res.x / res.y;
-    uv.x *= aspect;
-
-    vec3 col;
-
-    if (uZoom < 4e-4){
-        vec2 offs[4];
-        offs[0]=vec2(-0.25,-0.25); offs[1]=vec2( 0.25,-0.25);
-        offs[2]=vec2(-0.25, 0.25); offs[3]=vec2( 0.25, 0.25);
-        vec3 acc = vec3(0.0);
-        for (int i=0;i<4;++i){
-            vec2 uv2 = (gl_FragCoord.xy + offs[i]) * px * 2.0 - 1.0;
-            uv2.x *= aspect;
-            acc += colorize(center + uv2 * uZoom);
-        }
-        col = acc * 0.25;
-    }else{
-        col = colorize(center + uv * uZoom);
+    vec2 c = uCenter + uv * uZoom;
+    vec2 z = vec2(0.0);
+    int i;
+    for(i=0;i<uMaxIter && dot(z,z) < 4.0; ++i){
+        z = vec2(z.x*z.x - z.y*z.y, 2.0*z.x*z.y) + c;
     }
-
-    gl_FragColor = vec4(col, 1.0);
+    if(i==uMaxIter){
+        gl_FragColor = vec4(0.0,0.0,0.0,1.0);
+    }else{
+        float mu = float(i) - log2(log2(dot(z,z))) + 1.0;
+        float t = mu / float(uMaxIter);
+        gl_FragColor = vec4(palette(t),1.0);
+    }
 }

--- a/portfolio_menusystem.cpp
+++ b/portfolio_menusystem.cpp
@@ -655,7 +655,7 @@ static const SDL_Color kMonoGreenBase  = {120, 220, 120, 255};
 static const SDL_Color kMonoGreenHover = {170, 255, 170, 255};
 static const SDL_Color kCRTTint        = {30, 80, 30, 255};
 
-void renderPortfolioEffect(SDL_Renderer*, float deltaTime);
+bool renderPortfolioEffect(SDL_Renderer*, float deltaTime);
 void renderAboutC64Typewriter(SDL_Renderer* ren, float dt);
 
 SDL_Renderer* renderer = nullptr;
@@ -1734,7 +1734,7 @@ static void drawCone(int segs) {
 static const int GRID_W = 20;
 static const int GRID_H = 20;
 static const int CELL = 20;
-static const int WORM_MAX_SCORE = 10.0f;
+static const int WORM_MAX_SCORE = 10;
 static int snakeDir = 0;
 static float snakeTimer = 0.f;
 static SDL_Point food{ 0,0 };
@@ -1938,7 +1938,7 @@ static std::vector<FireworkParticle> pongFireworks; // local fireworks just for 
 // Layout & tuning
 static const int   PONG_PADDLE_INSET = 14;      // distance from frame edge
 static const Uint8 PONG_BG_ALPHA = 110;     // transparency of the black box (0..255)
-static const int   WIN_SCORE = 15.0f;      // win threshold
+static const int   WIN_SCORE = 15;      // win threshold
 
 // Speeds (slightly slower overall; AI a bit faster than player)
 static const float PONG_PLAYER_SPEED = 420.f;
@@ -2000,7 +2000,7 @@ static void pongRenderFireworks(SDL_Renderer* ren, const SDL_Rect& frame) {
 static void pongServeBall(const SDL_Rect& frame, int dirX) {
     ballX = frame.x + frame.w / 2.f;
     ballY = frame.y + frame.h / 2.f;
-    float vyRand = ((rand() % 200) - 100); // -100..+100
+    float vyRand = static_cast<float>((rand() % 200) - 100); // -100..+100
     ballVX = dirX * BALL_START_VX;
     ballVY = BALL_START_VY * (vyRand / 100.f);
     if (ballVY == 0.f) ballVY = 80.f; // avoid perfectly horizontal serves
@@ -2390,9 +2390,9 @@ void renderFractalZoom(SDL_Renderer* ren, float dt)
     };
     constexpr int numTargets = int(sizeof(targets) / sizeof(targets[0]));
 
-    const float  flyTime = 2.2f;
-    const float  holdTime = 0.6f;
-    const double zoomFactorPerFly = 0.18;
+    const float  flyTime = 1.2f;
+    const float  holdTime = 0.3f;
+    const double zoomFactorPerFly = 0.35;
     const double minZoom = 8e-6;
 
     enum Phase { Fly, Hold };
@@ -2422,7 +2422,7 @@ void renderFractalZoom(SDL_Renderer* ren, float dt)
         zoom = startZoom;
     }
 
-    phaseTime += (phase == Fly ? dt * 1.7f : dt);
+    phaseTime += (phase == Fly ? dt * 2.5f : dt);
 
     auto ease = [](float t) {
         if (t < 0.f) t = 0.f; else if (t > 1.f) t = 1.f;
@@ -2442,30 +2442,11 @@ void renderFractalZoom(SDL_Renderer* ren, float dt)
     {
         float t = ease(phaseTime / flyTime);
 
-        // Lerp
-        double cx = startX + (targetX - startX) * (double)t;
-        double cy = startY + (targetY - startY) * (double)t;
-
-        // [FIX] Geometrisk zoom först (behövs för clampen nedan)
+        // Lerp center and geometric zoom
+        centerX = startX + (targetX - startX) * (double)t;
+        centerY = startY + (targetY - startY) * (double)t;
         zoom = startZoom * pow(endZoom / startZoom, (double)t);
         if (zoom < minZoom) zoom = minZoom;
-
-        // [FIX] Komponent-vis clamp av pan relativt zoom & aspect:
-        // tillåten max-förskjutning i komplexplanet för att hålla motivet i ruta
-        const double k = 0.35;             // “hur stor del av halvbredd/halvhöjd” (0.25–0.5)
-        const double maxDx = aspect * zoom * k;  // x når kanten vid ±aspect*uZoom
-        const double maxDy = 1.0 * zoom * k;   // y når kanten vid ±1*uZoom
-
-        double dx = cx - startX;
-        double dy = cy - startY;
-
-        if (dx > maxDx) dx = maxDx;
-        if (dx < -maxDx) dx = -maxDx;
-        if (dy > maxDy) dy = maxDy;
-        if (dy < -maxDy) dy = -maxDy;
-
-        centerX = startX + dx;
-        centerY = startY + dy;
 
         if (t >= 1.f) { phase = Hold; phaseTime = 0.f; }
     }
@@ -2510,13 +2491,8 @@ void renderFractalZoom(SDL_Renderer* ren, float dt)
     glUniform2f(glGetUniformLocation(mandelbrotShader, "uCenter"), (float)animX, (float)animY);
     glUniform2i(glGetUniformLocation(mandelbrotShader, "uResolution"), viewW, viewH);
 
-    float depthFactor = (float)std::log10f((float)(startZoom / zoom) + 1.0f);
-    int   maxIter = std::min(7000, 4000 + int(12000.f * depthFactor));
+    int maxIter = 600;
     glUniform1i(glGetUniformLocation(mandelbrotShader, "uMaxIter"), maxIter);
-
-    glUniform1f(glGetUniformLocation(mandelbrotShader, "uBrightness"), 1.19f);
-    glUniform1f(glGetUniformLocation(mandelbrotShader, "uGamma"), 1.1f);
-    glUniform1f(glGetUniformLocation(mandelbrotShader, "uContrast"), 1.80f);
 
     glBindVertexArray(mandelbrotVAO);
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
@@ -2878,7 +2854,8 @@ void startExitExplosion(bool returnToMenu, bool nextEffect, int nextIndex)
     explosionNextIndex = nextIndex;
 }
 
-void renderPortfolioEffect(SDL_Renderer* ren, float deltaTime) {
+bool renderPortfolioEffect(SDL_Renderer* ren, float deltaTime) {
+    bool usedGL = false;
 
     switch (currentPortfolioSubState) {
 
@@ -2903,7 +2880,7 @@ void renderPortfolioEffect(SDL_Renderer* ren, float deltaTime) {
                 WF_FlyOut = false; WF_FlyT = 0.f;
                 currentEffectIndex = (currentEffectIndex + 1) % NUM_EFFECTS;
                 startPortfolioEffect(effectSequence[currentEffectIndex]);
-                return;
+                return usedGL;
             }
         }
 
@@ -3028,6 +3005,7 @@ void renderPortfolioEffect(SDL_Renderer* ren, float deltaTime) {
 
     case VIEW_FRACTAL_ZOOM:
         renderFractalZoom(ren, deltaTime);
+        usedGL = true;
         break;
 
     case VIEW_SNAKE_GAME:
@@ -3040,13 +3018,31 @@ void renderPortfolioEffect(SDL_Renderer* ren, float deltaTime) {
         renderPongGame(ren, deltaTime);
         break;
 
-    case VIEW_C64_10PRINT:
-		updateC64Window(deltaTime);
+    case VIEW_C64_10PRINT: {
+        static bool c64Started = false;
+        if (!c64Started) {
+            ensureGLContextCurrent();
+            startC64Window();
+            c64Started = true;
+        }
+
+        ensureGLContextCurrent();
+        updateC64Window(deltaTime);
         renderC64Window(SCREEN_WIDTH, SCREEN_HEIGHT);
-		break;
+        usedGL = true;
+
+        if (c64WindowIsDone()) {
+            c64Started = false;
+            int idx = (currentEffectIndex + 1) % NUM_EFFECTS;
+            startStarTransition(idx);
+        }
+        break;
+    }
 
     default: break;
     }
+
+    return usedGL;
 }
 
 
@@ -3184,6 +3180,8 @@ static float C64Time = 0.f;
 static float C64Decomp = 0.f;           // 0..1
 static bool C64DecompPhase = true;      // visa decrunch först
 static bool C64Done = false;
+static bool C64Boot = false;
+static float C64BootT = 0.f;
 
 // Create GL_R8 random texture of size w x h
 static GLuint makeRandTex(int w, int h) {
@@ -3231,34 +3229,33 @@ void startC64Window() { // resetta för nästa visning om du vill
     C64Decomp = 0.f;
     C64DecompPhase = true;
     C64Done = false;
+    C64Boot = false;
+    C64BootT = 0.f;
 }
 
 void updateC64Window(float dt) {
     C64Time += dt;
 
     if (C64DecompPhase) {
-        // kör "decrunch" ~2.5s
-        const float decompDur = 5.0f;
+        const float decompDur = 2.5f;
         C64Decomp = std::min(1.f, C64Time / decompDur);
         if (C64Decomp >= 1.f) {
             C64DecompPhase = false;
-            // starta reveal
+            C64Boot = true;
+            C64BootT = 0.f;
             C64Reveal = 0;
         }
-    }
-    else {
-        // reveal X cells per second
+    } else if (C64Boot) {
+        C64BootT += dt;
+        if (C64BootT > 2.0f) {
+            C64Boot = false;
+        }
+    } else {
         int total = C64GridW * C64GridH;
-        int add = int(2200.f * dt); // testa fart; 2200 celler/s
+        int add = int(2200.f * dt);
         C64Reveal = std::min(total, C64Reveal + add);
         if (C64Reveal == total) {
-            // håll uppe bilden en stund och markera klar
-            static float hold = 0.f;
-            hold += dt;
-            if (hold > 1.0f) {
-                C64Done = true;
-                hold = 0.f;
-            }
+            C64Done = true;
         }
     }
 }
@@ -3301,9 +3298,27 @@ void renderC64Window(int screenW, int screenH) {
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
     glBindVertexArray(0);
 
-    SDL_Rect menuRect{ 0,0,SCREEN_WIDTH,50 };
-    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 180);
-    SDL_RenderFillRect(renderer, &menuRect);
+    if (C64Boot) {
+        int w = int(panelW * screenW);
+        int h = int(panelH * screenH);
+        int x = (screenW - w) / 2;
+        int y = (screenH - h) / 2;
+        TTF_Font* f = consoleFont ? consoleFont : menuFont;
+        SDL_Color col{120,255,120,255};
+        auto drawLine = [&](const char* s, int line) {
+            if (SDL_Texture* t = renderText(renderer, f, s, col)) {
+                int tw, th; SDL_QueryTexture(t, nullptr, nullptr, &tw, &th);
+                SDL_Rect dst{ x + 20, y + 20 + line * (th + 4), tw, th };
+                SDL_RenderCopy(renderer, t, nullptr, &dst);
+                SDL_DestroyTexture(t);
+            }
+        };
+        drawLine("**** COMMODORE 64 BASIC V2 ****", 0);
+        drawLine("64K RAM SYSTEM  38911 BASIC BYTES FREE", 1);
+        drawLine("READY.", 2);
+        drawLine("10 PRINT CHR$(205.5+RND(1));:GOTO 10", 4);
+        drawLine("RUN", 5);
+    }
 }
 
 
@@ -3436,9 +3451,6 @@ int main(int argc, char* argv[]) {
     bool running = true;
     Uint32 lastTicks = SDL_GetTicks();
 
-    // === C64 10 PRINT === startflagga
-    static bool c64Started = false;
-
     while (running) {
         Uint32 cur = SDL_GetTicks();
         bool usedGLThisFrame = false;
@@ -3452,8 +3464,6 @@ int main(int argc, char* argv[]) {
         if (!starTransition) effectTimer += deltaTime;
 
         if (starTransition) {
-            c64Started = false;
-
             starTransitionTime += deltaTime;
             float t = starTransitionTime / starTransitionDuration;
             if (t > 1.f) t = 1.f;
@@ -3633,113 +3643,88 @@ int main(int argc, char* argv[]) {
             SDL_RenderFlush(renderer);
 
             if (!starTransition) {
-                renderPortfolioEffect(renderer, deltaTime);
+                usedGLThisFrame = renderPortfolioEffect(renderer, deltaTime);
             }
 
-            // === C64 10 PRINT ===
-            if (!starTransition && currentPortfolioSubState == VIEW_C64_10PRINT) {
-                // starta en gång
-                if (!c64Started) {
-                    ensureGLContextCurrent();
-                    startC64Window();
-                    c64Started = true;
+            if (currentPortfolioSubState != VIEW_C64_10PRINT) {
+                SDL_Point mp{ mouseX, mouseY };
+                bool hovBack = SDL_PointInRect(&mp, &backButtonRect);
+                bool hovNext = SDL_PointInRect(&mp, &nextButtonRect);
+                bool hovQuit = SDL_PointInRect(&mp, &quitButtonRect);
+                if (hovBack && !backWasHovered && hoverSound) {
+                    Mix_PlayChannel(-1, hoverSound, 0);
+                    backWasHovered = true;
+                }
+                else if (!hovBack) {
+                    backWasHovered = false;
+                }
+                if (hovNext && !nextWasHovered && hoverSound) {
+                    Mix_PlayChannel(-1, hoverSound, 0);
+                    nextWasHovered = true;
+                }
+                else if (!hovNext) {
+                    nextWasHovered = false;
+                }
+                if (hovQuit && !quitWasHovered && hoverSound) {
+                    Mix_PlayChannel(-1, hoverSound, 0);
+                    quitWasHovered = true;
+                }
+                else if (!hovQuit) {
+                    quitWasHovered = false;
                 }
 
-                // uppdatera + rendera
-                ensureGLContextCurrent();
-                updateC64Window(deltaTime);
-                renderC64Window(SCREEN_WIDTH, SCREEN_HEIGHT);
+                backHoverAnim += (hovBack ? 1.f : -1.f) * deltaTime * 6.f;
+                backHoverAnim = clampValue(backHoverAnim, 0.f, 1.f);
+                nextHoverAnim += (hovNext ? 1.f : -1.f) * deltaTime * 6.f;
+                nextHoverAnim = clampValue(nextHoverAnim, 0.f, 1.f);
+                quitHoverAnim += (hovQuit ? 1.f : -1.f) * deltaTime * 6.f;
+                quitHoverAnim = clampValue(quitHoverAnim, 0.f, 1.f);
 
-                // usedGLThisFrame = true;
+                SDL_Color bc = hovBack ? kMonoGreenHover : kMonoGreenBase;
+                SDL_Color sc = hovNext ? kMonoGreenHover : kMonoGreenBase;
+                SDL_Color qc = hovQuit ? kMonoGreenHover : kMonoGreenBase;
 
-                // när flyget är klart -> vidare till nästa effekt
-                if (c64WindowIsDone()) {
-                    int idx = (currentEffectIndex + 1) % NUM_EFFECTS;
+                SDL_Texture* backTex = renderText(renderer, menuFont, "[Back]", bc);
+                SDL_Texture* nextTex = renderText(renderer, menuFont, "[Next]", sc);
+                SDL_Texture* quitTex = renderText(renderer, menuFont, "[Main]", qc);
+
+                SDL_Rect bdst = backButtonRect; bdst.y -= static_cast<int>(6.f * backHoverAnim); // cast
+                SDL_Rect ndst = nextButtonRect; ndst.y -= static_cast<int>(6.f * nextHoverAnim); // cast
+                SDL_Rect qdst = quitButtonRect; qdst.y -= static_cast<int>(6.f * quitHoverAnim); // cast
+
+                SDL_RenderCopy(renderer, backTex, nullptr, &bdst);
+                SDL_RenderCopy(renderer, nextTex, nullptr, &ndst);
+                SDL_RenderCopy(renderer, quitTex, nullptr, &qdst);
+
+                applyDotMask(renderer, bdst);
+                applyScanlines(renderer, bdst, 2);
+                applyDotMask(renderer, ndst);
+                applyScanlines(renderer, ndst, 2);
+                applyDotMask(renderer, qdst);
+                applyScanlines(renderer, qdst, 2);
+
+                SDL_DestroyTexture(backTex);
+                SDL_DestroyTexture(nextTex);
+                SDL_DestroyTexture(quitTex);
+
+                if (mouseClick && hovBack && !starTransition) {
+                    int idx = (currentEffectIndex - 1 + NUM_EFFECTS) % NUM_EFFECTS;
                     startStarTransition(idx);
+
                 }
-            }
+                else if (mouseClick && hovNext && !starTransition) {
+                    if (currentPortfolioSubState == VIEW_WIREFRAME_CUBE) {
+                        if (!WF_FlyOut) { WF_FlyOut = true; WF_FlyT = 0.f; }
+                    }
+                    else {
+                        int idx = (currentEffectIndex + 1) % NUM_EFFECTS;
+                        startStarTransition(idx);
+                    }
 
-            SDL_Point mp{ mouseX, mouseY };
-            bool hovBack = SDL_PointInRect(&mp, &backButtonRect);
-            bool hovNext = SDL_PointInRect(&mp, &nextButtonRect);
-            bool hovQuit = SDL_PointInRect(&mp, &quitButtonRect);
-            if (hovBack && !backWasHovered && hoverSound) {
-                Mix_PlayChannel(-1, hoverSound, 0);
-                backWasHovered = true;
-            }
-            else if (!hovBack) {
-                backWasHovered = false;
-            }
-            if (hovNext && !nextWasHovered && hoverSound) {
-                Mix_PlayChannel(-1, hoverSound, 0);
-                nextWasHovered = true;
-            }
-            else if (!hovNext) {
-                nextWasHovered = false;
-            }
-            if (hovQuit && !quitWasHovered && hoverSound) {
-                Mix_PlayChannel(-1, hoverSound, 0);
-                quitWasHovered = true;
-            }
-            else if (!hovQuit) {
-                quitWasHovered = false;
-            }
-
-            backHoverAnim += (hovBack ? 1.f : -1.f) * deltaTime * 6.f;
-            backHoverAnim = clampValue(backHoverAnim, 0.f, 1.f);
-            nextHoverAnim += (hovNext ? 1.f : -1.f) * deltaTime * 6.f;
-            nextHoverAnim = clampValue(nextHoverAnim, 0.f, 1.f);
-            quitHoverAnim += (hovQuit ? 1.f : -1.f) * deltaTime * 6.f;
-            quitHoverAnim = clampValue(quitHoverAnim, 0.f, 1.f);
-
-            SDL_Color bc = hovBack ? kMonoGreenHover : kMonoGreenBase;
-            SDL_Color sc = hovNext ? kMonoGreenHover : kMonoGreenBase;
-            SDL_Color qc = hovQuit ? kMonoGreenHover : kMonoGreenBase;
-
-            SDL_Texture* backTex = renderText(renderer, menuFont, "[Back]", bc);
-            SDL_Texture* nextTex = renderText(renderer, menuFont, "[Next]", sc);
-            SDL_Texture* quitTex = renderText(renderer, menuFont, "[Main]", qc);
-
-            SDL_Rect bdst = backButtonRect; bdst.y -= static_cast<int>(6.f * backHoverAnim); // cast
-            SDL_Rect ndst = nextButtonRect; ndst.y -= static_cast<int>(6.f * nextHoverAnim); // cast
-            SDL_Rect qdst = quitButtonRect; qdst.y -= static_cast<int>(6.f * quitHoverAnim); // cast
-
-            SDL_RenderCopy(renderer, backTex, nullptr, &bdst);
-            SDL_RenderCopy(renderer, nextTex, nullptr, &ndst);
-            SDL_RenderCopy(renderer, quitTex, nullptr, &qdst);
-
-            applyDotMask(renderer, bdst);
-            applyScanlines(renderer, bdst, 2);
-            applyDotMask(renderer, ndst);
-            applyScanlines(renderer, ndst, 2);
-            applyDotMask(renderer, qdst);
-            applyScanlines(renderer, qdst, 2);
-
-            SDL_DestroyTexture(backTex);
-            SDL_DestroyTexture(nextTex);
-            SDL_DestroyTexture(quitTex);
-
-            if (mouseClick && hovBack && !starTransition) {
-                int idx = (currentEffectIndex - 1 + NUM_EFFECTS) % NUM_EFFECTS;
-                startStarTransition(idx);
-
-            }
-            else if (mouseClick && hovNext && !starTransition) {
-                if (currentPortfolioSubState == VIEW_C64_10PRINT) {
-                    // NEXT i C64-vyn triggar bara flyganimationen i rutan
-                    c64RequestFly();
                 }
-                else if (currentPortfolioSubState == VIEW_WIREFRAME_CUBE) {
-                    if (!WF_FlyOut) { WF_FlyOut = true; WF_FlyT = 0.f; }
+                else if (mouseClick && hovQuit && !starTransition) {
+                    startStarTransition(currentEffectIndex, true);
                 }
-                else {
-                    int idx = (currentEffectIndex + 1) % NUM_EFFECTS;
-                    startStarTransition(idx);
-                }
-
-            }
-            else if (mouseClick && hovQuit && !starTransition) {
-                startStarTransition(currentEffectIndex, true);
             }
         }
 


### PR DESCRIPTION
## Summary
- centralize portfolio effect rendering and rework C64 stage to decrunch, show classic BASIC screen, run the 10 PRINT program and auto-advance
- remove menu overlay during the C64 effect and handle GL swapping automatically
- simplify and speed up the Mandelbrot zoom with a vivid color palette
- fix type-conversion warnings in gameplay constants and random velocity

## Testing
- `g++ -std=c++17 -c portfolio_menusystem.cpp` *(fails: SDL.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d8c109eb88329a2a315de4e601238