### PR TITLE
Fix C64 window update brace mismatch

### DIFF
--- a/portfolio_menusystem.cpp
+++ b/portfolio_menusystem.cpp
@@ -3254,16 +3254,10 @@ void updateC64Window(float dt) {
         }
     } else {
         int total = C64GridW * C64GridH;
-        int add = int(2200.f * dt);
-        C64Reveal = std::min(total, C64Reveal + add);
-        if (C64Reveal == total) {
-            C64Done = true;
-
         int add = int(2200.f * dt); // 2200 celler/s
         C64Reveal = std::min(total, C64Reveal + add);
         if (C64Reveal == total) {
             C64Done = true; // mönstret är klart, men vi låter det ligga kvar
-
         }
     }
 }


### PR DESCRIPTION
## Summary
- Remove duplicated code in `updateC64Window` to restore proper brace structure and eliminate dead code.

## Testing
- `g++ -std=c++17 -c portfolio_menusystem.cpp` *(fails: SDL.h not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689d968d443483299497a8b8e9f5704f