### PR TITLE
Fix duplicated hover handling causing variable redefinitions

### DIFF
--- a/portfolio_menusystem.cpp
+++ b/portfolio_menusystem.cpp
@@ -3645,14 +3645,7 @@ int main(int argc, char* argv[]) {
             SDL_RenderFlush(renderer);
 
             if (!starTransition) {
-
                 usedGLThisFrame = renderPortfolioEffect(renderer, deltaTime);
-                usedGLThisFrame = renderPortfolioEffect(renderer, deltaTime);
-
-                if (currentPortfolioSubState != VIEW_C64_10PRINT) {
-                    renderPortfolioEffect(renderer, deltaTime);
-                }
-
             }
 
             if (currentPortfolioSubState != VIEW_C64_10PRINT) {
@@ -3660,113 +3653,25 @@ int main(int argc, char* argv[]) {
                 bool hovBack = SDL_PointInRect(&mp, &backButtonRect);
                 bool hovNext = SDL_PointInRect(&mp, &nextButtonRect);
                 bool hovQuit = SDL_PointInRect(&mp, &quitButtonRect);
+
                 if (hovBack && !backWasHovered && hoverSound) {
                     Mix_PlayChannel(-1, hoverSound, 0);
                     backWasHovered = true;
-
-                }
-                else if (!hovBack) {
+                } else if (!hovBack) {
                     backWasHovered = false;
                 }
+
                 if (hovNext && !nextWasHovered && hoverSound) {
                     Mix_PlayChannel(-1, hoverSound, 0);
                     nextWasHovered = true;
-
-                }
-
-                else if (!hovBack) {
-                    backWasHovered = false;
-                }
-                if (hovNext && !nextWasHovered && hoverSound) {
-                    Mix_PlayChannel(-1, hoverSound, 0);
-                    nextWasHovered = true;
-
-
-                // uppdatera + rendera
-                ensureGLContextCurrent();
-                updateC64Window(deltaTime);
-                renderC64Window(SCREEN_WIDTH, SCREEN_HEIGHT);
-                usedGLThisFrame = true;
-            }
-
-            SDL_Point mp{ mouseX, mouseY };
-            bool hovBack = SDL_PointInRect(&mp, &backButtonRect);
-            bool hovNext = SDL_PointInRect(&mp, &nextButtonRect);
-            bool hovQuit = SDL_PointInRect(&mp, &quitButtonRect);
-            if (hovBack && !backWasHovered && hoverSound) {
-                Mix_PlayChannel(-1, hoverSound, 0);
-                backWasHovered = true;
-            }
-            else if (!hovBack) {
-                backWasHovered = false;
-            }
-            if (hovNext && !nextWasHovered && hoverSound) {
-                Mix_PlayChannel(-1, hoverSound, 0);
-                nextWasHovered = true;
-            }
-            else if (!hovNext) {
-                nextWasHovered = false;
-            }
-            if (hovQuit && !quitWasHovered && hoverSound) {
-                Mix_PlayChannel(-1, hoverSound, 0);
-                quitWasHovered = true;
-            }
-            else if (!hovQuit) {
-                quitWasHovered = false;
-            }
-
-            backHoverAnim += (hovBack ? 1.f : -1.f) * deltaTime * 6.f;
-            backHoverAnim = clampValue(backHoverAnim, 0.f, 1.f);
-            nextHoverAnim += (hovNext ? 1.f : -1.f) * deltaTime * 6.f;
-            nextHoverAnim = clampValue(nextHoverAnim, 0.f, 1.f);
-            quitHoverAnim += (hovQuit ? 1.f : -1.f) * deltaTime * 6.f;
-            quitHoverAnim = clampValue(quitHoverAnim, 0.f, 1.f);
-
-            SDL_Color bc = hovBack ? kMonoGreenHover : kMonoGreenBase;
-            SDL_Color sc = hovNext ? kMonoGreenHover : kMonoGreenBase;
-            SDL_Color qc = hovQuit ? kMonoGreenHover : kMonoGreenBase;
-
-            SDL_Texture* backTex = renderText(renderer, menuFont, "[Back]", bc);
-            SDL_Texture* nextTex = renderText(renderer, menuFont, "[Next]", sc);
-            SDL_Texture* quitTex = renderText(renderer, menuFont, "[Main]", qc);
-
-            SDL_Rect bdst = backButtonRect; bdst.y -= static_cast<int>(6.f * backHoverAnim); // cast
-            SDL_Rect ndst = nextButtonRect; ndst.y -= static_cast<int>(6.f * nextHoverAnim); // cast
-            SDL_Rect qdst = quitButtonRect; qdst.y -= static_cast<int>(6.f * quitHoverAnim); // cast
-
-            SDL_RenderCopy(renderer, backTex, nullptr, &bdst);
-            SDL_RenderCopy(renderer, nextTex, nullptr, &ndst);
-            SDL_RenderCopy(renderer, quitTex, nullptr, &qdst);
-
-            applyDotMask(renderer, bdst);
-            applyScanlines(renderer, bdst, 2);
-            applyDotMask(renderer, ndst);
-            applyScanlines(renderer, ndst, 2);
-            applyDotMask(renderer, qdst);
-            applyScanlines(renderer, qdst, 2);
-
-            SDL_DestroyTexture(backTex);
-            SDL_DestroyTexture(nextTex);
-            SDL_DestroyTexture(quitTex);
-
-            if (mouseClick && hovBack && !starTransition) {
-                int idx = (currentEffectIndex - 1 + NUM_EFFECTS) % NUM_EFFECTS;
-                startStarTransition(idx);
-
-            }
-            else if (mouseClick && hovNext && !starTransition) {
-                if (currentPortfolioSubState == VIEW_C64_10PRINT) {
-                    // NEXT i C64-vyn triggar bara flyganimationen i rutan
-                    c64RequestFly();
-                }
-                else if (!hovNext) {
+                } else if (!hovNext) {
                     nextWasHovered = false;
                 }
+
                 if (hovQuit && !quitWasHovered && hoverSound) {
                     Mix_PlayChannel(-1, hoverSound, 0);
                     quitWasHovered = true;
-                }
-                else if (!hovQuit) {
+                } else if (!hovQuit) {
                     quitWasHovered = false;
                 }
 
@@ -3785,9 +3690,9 @@ int main(int argc, char* argv[]) {
                 SDL_Texture* nextTex = renderText(renderer, menuFont, "[Next]", sc);
                 SDL_Texture* quitTex = renderText(renderer, menuFont, "[Main]", qc);
 
-                SDL_Rect bdst = backButtonRect; bdst.y -= static_cast<int>(6.f * backHoverAnim); // cast
-                SDL_Rect ndst = nextButtonRect; ndst.y -= static_cast<int>(6.f * nextHoverAnim); // cast
-                SDL_Rect qdst = quitButtonRect; qdst.y -= static_cast<int>(6.f * quitHoverAnim); // cast
+                SDL_Rect bdst = backButtonRect; bdst.y -= static_cast<int>(6.f * backHoverAnim);
+                SDL_Rect ndst = nextButtonRect; ndst.y -= static_cast<int>(6.f * nextHoverAnim);
+                SDL_Rect qdst = quitButtonRect; qdst.y -= static_cast<int>(6.f * quitHoverAnim);
 
                 SDL_RenderCopy(renderer, backTex, nullptr, &bdst);
                 SDL_RenderCopy(renderer, nextTex, nullptr, &ndst);
@@ -3807,19 +3712,17 @@ int main(int argc, char* argv[]) {
                 if (mouseClick && hovBack && !starTransition) {
                     int idx = (currentEffectIndex - 1 + NUM_EFFECTS) % NUM_EFFECTS;
                     startStarTransition(idx);
-
-                }
-                else if (mouseClick && hovNext && !starTransition) {
+                } else if (mouseClick && hovNext && !starTransition) {
                     if (currentPortfolioSubState == VIEW_WIREFRAME_CUBE) {
-                        if (!WF_FlyOut) { WF_FlyOut = true; WF_FlyT = 0.f; }
-                    }
-                    else {
+                        if (!WF_FlyOut) {
+                            WF_FlyOut = true;
+                            WF_FlyT = 0.f;
+                        }
+                    } else {
                         int idx = (currentEffectIndex + 1) % NUM_EFFECTS;
                         startStarTransition(idx);
                     }
-
-                }
-                else if (mouseClick && hovQuit && !starTransition) {
+                } else if (mouseClick && hovQuit && !starTransition) {
                     startStarTransition(currentEffectIndex, true);
                 }
             }


### PR DESCRIPTION
## Summary
- Clean up portfolio state input handling by removing duplicate variable declarations and redundant render calls.
- Consolidate hover logic for Back/Next/Main buttons into a single block.

## Testing
- `g++ -std=c++17 -fsyntax-only portfolio_menusystem.cpp` *(fails: fatal error: SDL.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d9834821c8329a5c25d03f88ebf5e