### PR TITLE
Move startExitExplosion prototype near top

### DIFF
--- a/portfolio_menusystem.cpp
+++ b/portfolio_menusystem.cpp
@@ -43,6 +43,8 @@
 
 struct Star;
 
+void startExitExplosion(bool returnToMenu = false, bool nextEffect = false, int nextIndex = 0);
+
 SDL_Window* gWindow = nullptr;
 SDL_GLContext gGL = nullptr;
 
@@ -1020,7 +1022,6 @@ void updatePongGame(float dt);
 void renderPongGame(SDL_Renderer* ren, float dt);       // main one
 void renderFireworks(SDL_Renderer*, float dt);
 void renderLogoWithReflection(SDL_Renderer*, SDL_Texture*, int baseX);
-void startExitExplosion(bool returnToMenu = false, bool nextEffect = false, int nextIndex = 0);
 void startStarTransition(int newIndex, bool toMenu = false);
 static void drawThickLine(SDL_Renderer* ren, int x1, int y1, int x2, int y2, int t);
 static void drawSmallFilledCircle(SDL_Renderer* ren, int cx, int cy, int radius);
@@ -4301,9 +4302,8 @@ int main() {
                     usedGLThisFrame = false; // presenterar via SDL
                 }
                 else {
-                    // Icke-fraktal: rita som vanligt (SDL)
-                    renderPortfolioEffect(renderer, deltaTime);
-                    usedGLThisFrame = false;
+                    // Rendera övriga effekter (kan använda OpenGL)
+                    usedGLThisFrame = renderPortfolioEffect(renderer, deltaTime);
                 }
             }
             else {


### PR DESCRIPTION
## Summary
- Move `startExitExplosion` forward declaration to the beginning of `portfolio_menusystem.cpp` so calls in early C64 fireworks logic compile cleanly.
- Use `renderPortfolioEffect`'s return value to swap the GL buffer so OpenGL-based effects, like the ethanol molecule, render instead of only the star scroller.

## Testing
- `g++ -std=c++17 -c portfolio_menusystem.cpp` *(fails: SDL.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a1fd98bef88329bfc010880e1f6691