### PR TITLE
Use glass shatter effect when C64PRINT_NEW ends

### DIFF
--- a/portfolio_menusystem.cpp
+++ b/portfolio_menusystem.cpp
@@ -3662,10 +3662,8 @@ bool renderPortfolioEffect(SDL_Renderer* ren, float deltaTime) {
                 c64ShatterTime = 0.f;
             }
 
-            if (!c64Shatter && c64PRINT_NEW_isDone()) {
-                inited = false;
-                int idx = (currentEffectIndex + 1) % NUM_EFFECTS;
-                startStarTransition(idx);
+            if (!c64Shatter && !c64ShatterRequest && c64PRINT_NEW_isDone()) {
+                c64ShatterRequest = true;  // trigger glass shatter instead of explosion
             }
         }
         usedGL = false;


### PR DESCRIPTION
## Summary
- trigger glass shatter effect after C64 print sequence instead of immediate explosion

## Testing
- `g++ -std=c++17 -c portfolio_menusystem.cpp` *(fails: SDL.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ef2e0b608329b66835cce83a7ae0