### PR TITLE
Expand C64 shatter effect and replace quit explosion

### DIFF
--- a/portfolio_menusystem.cpp
+++ b/portfolio_menusystem.cpp
@@ -1058,11 +1058,13 @@ bool explosionAdvanceEffect = false;
 int  explosionNextIndex = 0;
 
 // --- C64 window shatter ---
-struct Shard { SDL_Rect src; float x, y, vx, vy, ang, vang; };
+struct Shard { SDL_Texture* tex; float x, y, vx, vy, ang, vang; int w, h; };
 static std::vector<Shard> c64Shards;
-static SDL_Texture* c64Snapshot = nullptr;
 static bool c64Shatter = false;
 static bool c64ShatterRequest = false;
+static bool c64PendingQuit = false;
+static bool quitAfterShatter = false;
+static bool shatterExitComplete = false;
 static float c64ShatterTime = 0.f;
 
 
@@ -1680,7 +1682,11 @@ void renderMenu(float dt, int mX, int mY, bool mClick) {
                     startStarTransition(0);
                 }
                 else if (i == 1) {
-                    startExitExplosion(false);
+                    currentState = STATE_PORTFOLIO;
+                    currentPortfolioSubState = VIEW_C64PRINT_NEW;
+                    c64pnHardReset(SCREEN_WIDTH, SCREEN_HEIGHT);
+                    c64PendingQuit = true;
+                    quitAfterShatter = true;
                 }
             }
         }
@@ -3618,54 +3624,83 @@ bool renderPortfolioEffect(SDL_Renderer* ren, float deltaTime) {
                 s.x += s.vx * deltaTime;
                 s.y += s.vy * deltaTime;
                 s.ang += s.vang * deltaTime;
-                SDL_Rect dst{ int(s.x), int(s.y), s.src.w, s.src.h };
-                SDL_RenderCopyEx(renderer, c64Snapshot, &s.src, &dst, s.ang, nullptr, SDL_FLIP_NONE);
+                SDL_Rect dst{ int(s.x), int(s.y), s.w, s.h };
+                SDL_RenderCopyEx(renderer, s.tex, nullptr, &dst, s.ang, nullptr, SDL_FLIP_NONE);
             }
             if (c64ShatterTime > 1.2f) {
-                inited = false;
-                int idx = (currentEffectIndex + 1) % NUM_EFFECTS;
-                startStarTransition(idx);
-                c64Shatter = false;
+                for (auto &s : c64Shards) SDL_DestroyTexture(s.tex);
                 c64Shards.clear();
-                if (c64Snapshot) { SDL_DestroyTexture(c64Snapshot); c64Snapshot = nullptr; }
+                c64Shatter = false;
+                c64ShatterTime = 0.f;
+                if (quitAfterShatter) {
+                    shatterExitComplete = true;
+                    quitAfterShatter = false;
+                } else {
+                    inited = false;
+                    int idx = (currentEffectIndex + 1) % NUM_EFFECTS;
+                    startStarTransition(idx);
+                }
             }
         }
         else {
             for (int i = 0; i < 2; ++i) { c64pnUpdate(deltaTime); }
             renderC64PRINT_NEW(renderer, menuFont ? menuFont : titleFont, deltaTime, SCREEN_WIDTH, SCREEN_HEIGHT);
 
+            if (c64PendingQuit) { c64ShatterRequest = true; c64PendingQuit = false; }
+
             if (c64ShatterRequest) {
                 SDL_Surface* surf = SDL_CreateRGBSurfaceWithFormat(0, C64PN.outer.w, C64PN.outer.h, 32, SDL_PIXELFORMAT_ARGB8888);
                 SDL_RenderReadPixels(renderer, &C64PN.outer, SDL_PIXELFORMAT_ARGB8888, surf->pixels, surf->pitch);
-                c64Snapshot = SDL_CreateTextureFromSurface(renderer, surf);
-                SDL_FreeSurface(surf);
 
                 c64Shards.clear();
-                const int cols = 4, rows = 3;
+                const int cols = 8, rows = 5;
                 int pw = C64PN.outer.w / cols;
                 int ph = C64PN.outer.h / rows;
+                Uint32* basePixels = static_cast<Uint32*>(surf->pixels);
+                int basePitch = surf->pitch / 4;
                 for (int y = 0; y < rows; ++y) {
                     for (int x = 0; x < cols; ++x) {
-                        Shard sh;
-                        sh.src = { x*pw, y*ph, pw, ph };
-                        sh.x = float(C64PN.outer.x + sh.src.x);
-                        sh.y = float(C64PN.outer.y + sh.src.y);
-                        sh.vx = float(rand() % 200 - 100);
-                        sh.vy = float(rand() % 200);
-                        sh.ang = 0.f;
-                        sh.vang = float(rand() % 400 - 200);
-                        c64Shards.push_back(sh);
+                        bool slash = rand() % 2;
+                        SDL_Rect cell{ x*pw, y*ph, pw, ph };
+                        for (int t = 0; t < 2; ++t) {
+                            SDL_Surface* tri = SDL_CreateRGBSurfaceWithFormat(0, pw, ph, 32, SDL_PIXELFORMAT_ARGB8888);
+                            SDL_FillRect(tri, nullptr, SDL_MapRGBA(tri->format, 0, 0, 0, 0));
+                            Uint32* dstPixels = static_cast<Uint32*>(tri->pixels);
+                            for (int j = 0; j < ph; ++j) {
+                                for (int i = 0; i < pw; ++i) {
+                                    bool keep;
+                                    if (slash) {
+                                        keep = (t == 0) ? (i <= pw - 1 - j) : (i > pw - 1 - j);
+                                    } else {
+                                        keep = (t == 0) ? (i <= j) : (i > j);
+                                    }
+                                    if (keep) {
+                                        dstPixels[j*pw + i] = basePixels[(cell.y + j)*basePitch + (cell.x + i)];
+                                    }
+                                }
+                            }
+                            Shard sh;
+                            sh.tex = SDL_CreateTextureFromSurface(renderer, tri);
+                            sh.w = pw; sh.h = ph;
+                            sh.x = float(C64PN.outer.x + cell.x);
+                            sh.y = float(C64PN.outer.y + cell.y);
+                            sh.vx = float(rand() % 400 - 200);
+                            sh.vy = float(rand() % 400 - 200);
+                            sh.ang = 0.f;
+                            sh.vang = float(rand() % 720 - 360);
+                            c64Shards.push_back(sh);
+                            SDL_FreeSurface(tri);
+                        }
                     }
                 }
+                SDL_FreeSurface(surf);
                 c64Shatter = true;
                 c64ShatterRequest = false;
                 c64ShatterTime = 0.f;
             }
 
-            if (!c64Shatter && c64PRINT_NEW_isDone()) {
-                inited = false;
-                int idx = (currentEffectIndex + 1) % NUM_EFFECTS;
-                startStarTransition(idx);
+            if (!c64Shatter && !c64ShatterRequest && c64PRINT_NEW_isDone()) {
+                c64ShatterRequest = true;  // trigger glass shatter instead of explosion
             }
         }
         usedGL = false;
@@ -4381,6 +4416,7 @@ int main() {
                 else {
                     // Rendera övriga effekter (kan använda OpenGL)
                     usedGLThisFrame = renderPortfolioEffect(renderer, deltaTime);
+                    if (shatterExitComplete) { running = false; shatterExitComplete = false; }
                 }
             }
             else {


### PR DESCRIPTION
## Summary
- Split the C64 window into many triangular shards with randomized velocities for a richer glass-break effect
- Replace the Quit menu explosion with the same glass shatter animation and exit once shards fall away

## Testing
- `g++ -std=c++17 -c portfolio_menusystem.cpp` *(fails: SDL.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ef2e0b608329b66835cce83a7ae0