### PR TITLE
Add break sound to window shatter

### DIFF
--- a/portfolio_menusystem.cpp
+++ b/portfolio_menusystem.cpp
@@ -1725,6 +1725,7 @@ void renderMenu(float dt, int mX, int mY, bool mClick) {
                         }
                     }
                     SDL_FreeSurface(surf);
+                    if (bangSound) Mix_PlayChannel(-1, bangSound, 0);
                     c64Shatter = true;
                     c64ShatterRequest = false;
                     c64PendingQuit = false;
@@ -3748,6 +3749,7 @@ bool renderPortfolioEffect(SDL_Renderer* ren, float deltaTime) {
                     }
                 }
                 SDL_FreeSurface(surf);
+                if (bangSound) Mix_PlayChannel(-1, bangSound, 0);
                 c64Shatter = true;
                 c64ShatterRequest = false;
                 c64ShatterTime = 0.f;


### PR DESCRIPTION
## Summary
- Play break sound when C64 window shatters so effect has audio impact
- Sound playback keeps background music running

## Testing
- `g++ -std=c++17 portfolio_menusystem.cpp -lSDL2 -lSDL2_image -lSDL2_ttf -lSDL2_mixer -lGLEW -lGL -lGLU -o portfolio_menusystem` *(fails: SDL.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a2fe897dbc832981c58ce02ca3f494