### PR TITLE
Remove unused renderFireworks wrapper

### DIFF
--- a/portfolio_menusystem.cpp
+++ b/portfolio_menusystem.cpp
@@ -288,11 +288,6 @@ void renderFireworks(SDL_Renderer* renderer, float dt);
 // Global senaste dt (du har redan denna):
 extern float gLastDt;
 
-// Wrappern (placera i .cpp, efter att gLastDt finns)
-inline void renderFireworks(SDL_Renderer* renderer) {
-    renderFireworks(renderer, gLastDt);
-}
-
 static inline void c64pnFillRect(SDL_Renderer* r, const SDL_Rect& rc, SDL_Color c) {
     SDL_SetRenderDrawColor(r, c.r, c.g, c.b, c.a);
     SDL_RenderFillRect(r, &rc);


### PR DESCRIPTION
## Summary
- Drop single-parameter `renderFireworks` wrapper so only two-parameter version remains.

## Testing
- `g++ -std=c++17 -fsyntax-only portfolio_menusystem.cpp` *(fails: SDL.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a31345f338832982449bcc61da2224