### PR TITLE
Fix C64 typewriter cursor color

### DIFF
--- a/portfolio_menusystem.cpp
+++ b/portfolio_menusystem.cpp
@@ -3374,7 +3374,7 @@ void renderAboutC64Typewriter(SDL_Renderer* ren, float dt) {
         int chW, chH;
         TTF_SizeText(f, "M", &chW, &chH);
         SDL_Rect cur{ cursorX + 4, cursorY + chH - (chH - 4), chW / 2, chH - 6 };
-        SDL_SetRenderDrawColor(ren, 120, 255, 120, 255);
+        SDL_SetRenderDrawColor(ren, 255, 255, 255, 255); // white cursor
         SDL_RenderFillRect(ren, &cur);
     }
 


### PR DESCRIPTION
## Summary
- ensure the C64 typewriter's blinking cursor renders in white

## Testing
- `g++ -std=c++17 -c portfolio_menusystem.cpp $(sdl2-config --cflags) -I/usr/include/SDL2` *(fails: command not found: sdl2-config)*

------
https://chatgpt.com/codex/tasks/task_e_68a316adbf2483299e41abc2f9f361c3