### PR TITLE
Refactor cursor size variables

### DIFF
--- a/portfolio_menusystem.cpp
+++ b/portfolio_menusystem.cpp
@@ -435,12 +435,9 @@ static void c64pnDrawBootText(SDL_Renderer* r, TTF_Font* font) {
 
         int readyW = 0, readyH = 0;
         TTF_SizeText(font, l3, &readyW, &readyH);
-        int cw = 0, ch = 0;
-        TTF_SizeText(font, "M", &cw, &ch);
-        SDL_Rect cur{ x + readyW, y, cw, ch };
-
-        int cw = static_cast<int>(C64PN.cellW * 0.6f);
-        SDL_Rect cur{ x + 6 * C64PN.cellW, y, cw, C64PN.cellH };
+        int charW = 0, charH = 0;
+        TTF_SizeText(font, "M", &charW, &charH);
+        SDL_Rect cur{ x + readyW, y, charW, charH };
         c64pnFillRect(r, cur, C64PN.cursorCol);
     }
 }
@@ -455,14 +452,9 @@ static void c64pnDrawTyping(SDL_Renderer* r, TTF_Font* font) {
 
         int textW = 0, textH = 0;
         TTF_SizeText(font, line.c_str(), &textW, &textH);
-        int cw = 0, ch = 0;
-        TTF_SizeText(font, "M", &cw, &ch);
-        SDL_Rect cur{ x + textW, y, cw, ch };
-
-        int approxW = static_cast<int>(line.size() * (C64PN.cellW * 0.6f));
-        int cw = static_cast<int>(C64PN.cellW * 0.6f);
-        SDL_Rect cur{ x + approxW, y, cw, C64PN.cellH };
-
+        int charW = 0, charH = 0;
+        TTF_SizeText(font, "M", &charW, &charH);
+        SDL_Rect cur{ x + textW, y, charW, charH };
         c64pnFillRect(r, cur, C64PN.cursorCol);
     }
 }


### PR DESCRIPTION
## Summary
- remove redundant cursor dimension calculations
- rename cursor width/height vars to charW/charH

## Testing
- `g++ -std=c++17 -c portfolio_menusystem.cpp -o /tmp/portfolio_menusystem.o` *(fails: SDL.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a3277ec4c88329a9c42512ea5ade9c